### PR TITLE
Changed admin secret to the one created by the new Java operator

### DIFF
--- a/deploy/examples/external-keycloak.yaml
+++ b/deploy/examples/external-keycloak.yaml
@@ -8,13 +8,4 @@ metadata:
 spec:
   url: https://example-kc-service:8443 # set to the Service created by the new Keycloak Operator
   contextRoot: /
----
-# The Admin Credentials need to match those used/created by the new Keycloak Operator
-apiVersion: v1
-kind: Secret
-metadata:
-  name: credential-external-keycloak
-type: Opaque
-stringData:
-  ADMIN_USERNAME: admin
-  ADMIN_PASSWORD: admin
+  

--- a/pkg/common/client.go
+++ b/pkg/common/client.go
@@ -1032,7 +1032,7 @@ func (i *LocalConfigKeycloakFactory) AuthenticatedClient(kc v1alpha1.ExternalKey
 	//} else {
 	//	credentialSecret = kc.Status.CredentialSecret
 	//}
-	credentialSecret := "credential-" + kc.Name
+	credentialSecret := kc.Name + "-initial-admin"
 
 	adminCreds, err := secretClient.CoreV1().Secrets(kc.Namespace).Get(context.TODO(), credentialSecret, v12.GetOptions{})
 	if err != nil {

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -36,8 +36,8 @@ const (
 	DatabaseSecretExternalPortProperty         = "POSTGRES_EXTERNAL_PORT"    // nolint
 	KeycloakServicePort                        = 8443
 	PostgresDefaultPort                        = 5432
-	AdminUsernameProperty                      = "ADMIN_USERNAME"
-	AdminPasswordProperty                      = "ADMIN_PASSWORD"
+	AdminUsernameProperty                      = "username"
+	AdminPasswordProperty                      = "password"
 	ServingCertSecretName                      = "sso-x509-https-secret" // nolint
 	LivenessProbeProperty                      = "liveness_probe.sh"
 	ReadinessProbeProperty                     = "readiness_probe.sh"

--- a/pkg/model/keycloak_admin_secret.go
+++ b/pkg/model/keycloak_admin_secret.go
@@ -10,7 +10,7 @@ import (
 func KeycloakAdminSecret(cr *v1alpha1.ExternalKeycloak) *v1.Secret {
 	return &v1.Secret{
 		ObjectMeta: v12.ObjectMeta{
-			Name:      "credential-" + cr.Name,
+			Name:      cr.Name + "-initial-admin",
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
 				"app":           ApplicationName,
@@ -27,7 +27,7 @@ func KeycloakAdminSecret(cr *v1alpha1.ExternalKeycloak) *v1.Secret {
 
 func KeycloakAdminSecretSelector(cr *v1alpha1.ExternalKeycloak) client.ObjectKey {
 	return client.ObjectKey{
-		Name:      "credential-" + cr.Name,
+		Name:      cr.Name + "-initial-admin",
 		Namespace: cr.Namespace,
 	}
 }


### PR DESCRIPTION
## Related GH Issue
Closes <!-- Your issue ID -->

## Additional Information
The "credential-(keycloak-name)" secret no longer exists when using the new Java operator to stand up Keycloak in K8s. It now uses "(keycloak-name)-initial-admin" This simply changes things to the new name so the old secret doesn't need to be manually created.

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->