### PR TITLE
Add reconciliation of authorization services in KeycloakClients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ setup/linter:
 code/run:
 	@operator-sdk run local --watch-namespace=${NAMESPACE}
 
+.PHONY: code/run-debug
+code/run-debug:
+	@operator-sdk run local --enable-delve --watch-namespace=${NAMESPACE}
+
 .PHONY: code/run-as-container
 code/run-as-container: code/delete-container
 	eval $$(minikube -p minikube docker-env); \

--- a/pkg/common/client_state.go
+++ b/pkg/common/client_state.go
@@ -25,6 +25,9 @@ type ClientState struct {
 	DeprecatedClientSecret  *v1.Secret // keycloak-client-secret-<clientID>
 	Keycloak                kc.ExternalKeycloak
 	ServiceAccountUserState *UserState
+	AuthorizationPolicies   []kc.KeycloakPolicy
+	AuthorizationResources  []kc.KeycloakResource
+	AuthorizationScopes     []kc.KeycloakScope
 }
 
 func NewClientState(context context.Context, realm *kc.KeycloakRealm, keycloak kc.ExternalKeycloak) *ClientState {
@@ -94,6 +97,20 @@ func (i *ClientState) Read(context context.Context, cr *kc.KeycloakClient, realm
 	err = i.readDefaultRoles(cr, realmClient)
 	if err != nil {
 		return err
+	}
+
+	if i.Client.AuthorizationServicesEnabled {
+		i.AuthorizationResources, err = realmClient.ListClientAuthorizationResources(cr.Spec.Client.ID, i.Realm.Spec.Realm.Realm)
+		if err != nil {
+			return err
+		}
+
+		i.AuthorizationPolicies, err = realmClient.ListClientAuthorizationPolicies(cr.Spec.Client.ID, i.Realm.Spec.Realm.Realm)
+		if err != nil {
+			return err
+		}
+
+		// TODO implement API for updating authorization scopes?
 	}
 
 	if i.Client.ServiceAccountsEnabled {

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -219,6 +219,82 @@ func FilterClientScopesByNames(clientScopes []v1alpha1.KeycloakClientScope, name
 	return filteredScopes
 }
 
+func AuthorizationPoliciesDifferenceIntersection(a []v1alpha1.KeycloakPolicy, b []v1alpha1.KeycloakPolicy) (d []v1alpha1.KeycloakPolicy, i []v1alpha1.KeycloakPolicy) {
+	for _, policy := range a {
+		if hasMatchingPolicy(b, policy) {
+			i = append(i, policy)
+		} else {
+			d = append(d, policy)
+		}
+	}
+
+	return d, i
+}
+
+func hasMatchingPolicy(policies []v1alpha1.KeycloakPolicy, otherPolicy v1alpha1.KeycloakPolicy) bool {
+	for _, policy := range policies {
+		if policyMatches(policy, otherPolicy) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func policyMatches(a v1alpha1.KeycloakPolicy, b v1alpha1.KeycloakPolicy) bool {
+	if a.ID != "" && b.ID != "" {
+		return a.ID == b.ID
+	}
+
+	return a.Name == b.Name
+}
+
+func AuthorizationResourcesDifferenceIntersection(a []v1alpha1.KeycloakResource, b []v1alpha1.KeycloakResource) (d []v1alpha1.KeycloakResource, i []v1alpha1.KeycloakResource) {
+	for _, resource := range a {
+		if hasMatchingResource(b, resource) {
+			i = append(i, resource)
+		} else {
+			d = append(d, resource)
+		}
+	}
+
+	return d, i
+}
+
+func hasMatchingResource(resources []v1alpha1.KeycloakResource, otherResource v1alpha1.KeycloakResource) bool {
+	for _, resource := range resources {
+		if resourceMatches(resource, otherResource) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func resourceMatches(a v1alpha1.KeycloakResource, b v1alpha1.KeycloakResource) bool {
+	if a.ID != "" && b.ID != "" {
+		return a.ID == b.ID
+	}
+
+	return a.Name == b.Name
+}
+
+func FilterAuthorizationPoliciesByName(policies []v1alpha1.KeycloakPolicy, names []string) (filteredPolicies []v1alpha1.KeycloakPolicy) {
+	hashMap := make(map[string]v1alpha1.KeycloakPolicy)
+
+	for _, policy := range policies {
+		hashMap[policy.Name] = policy
+	}
+
+	for _, name := range names {
+		if policy, retrieved := hashMap[name]; retrieved {
+			filteredPolicies = append(filteredPolicies, policy)
+		}
+	}
+
+	return filteredPolicies
+}
+
 func SanitizeResourceNameWithAlphaNum(text string) string {
 	// we only want letters and numbers
 	reg := []rune(SanitizeResourceName(text))


### PR DESCRIPTION
## Related GH Issue
Closes https://github.com/keycloak/keycloak-realm-operator/issues/11

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->
In KeycloakClients, you can specify settings for authorization services. In its current state, the operator is not able to handle them correctly. https://github.com/keycloak/keycloak/issues/16998 also addresses an issue with the client REST API because if the exported client.json contains authorization settings with policies referring to roles, the import fails because Keycloak cannot find the relevant roles at import time.

This MR adds a reconciliation logic explicitly for authorization settings and tries to maintain its state, regardless of the former mentioned issue.

## Verification Steps

1. Prepare a `KeycloakClient` CR containing `authorizationSettings`. This can be easily obtained by configuring authorization in Keycloak, then exporting the realm either via Admin Console or CLI.
2. Checkout and run this MR
3. Check the logs for reconciliation of authorization settings
4. Keycloak should no longer throw exceptions when importing clients containing authorization settings
5. Open authorization settings of the imported client in the Admin Console and check if the custom policies, resources etc. are present
6. Change some data and check if the operator overwrites them again
7. Change policy names and update references in CR to check if the operator can handle these changes

## Checklist:
- [x] Automated Tests
- [ ] ~[Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary~
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)